### PR TITLE
[tz-92] Allow owners to write their own repositories without requiring explicit permissions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ HEDGE has HUGE potential reach and potential CO2 reduction impact, with over 90%
 <img width="224" alt="Screen Shot 2022-11-07 at 7 42 26 PM" src="https://user-images.githubusercontent.com/73197190/200446064-8fb570e3-e0f2-4659-a19e-dda084c8a33e.png">
 
 * **Problem:** Traditional databases are resources intensive and wastful.
-* **Solution:** Repair data storage by using Github for storage.
+* **Solution:** Repair data storage by using Github.
 
 **Resolution:**
 

--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ Store Media and other files under 100MB in Github easily.
 
 # Support
 
+Roll the Cloud INC. is a registered 501(c)3 nonprofit US charity whose mission is to exhile carbon from the web.
+
 ## Contact Us
 
 * [Email](mailto:hi@rollthecloud.com)

--- a/README.md
+++ b/README.md
@@ -97,14 +97,6 @@ Store JSON in Github easily.
 | PUT  | https://edge.hedge.earth/octostore/owner/repo/shapeshifter/path/id  |
 | POST  | https://edge.hedge.earth/octostore/owner/repo/shapeshifter/path/id  |
 
-deprecated:
-
-| Method | HEDGE.earth |
-| ------------- | ------------- |
-| GET  | https://edge.hedge.earth/emissionless/owner/repo/shapeshifter/path/id  |
-| PUT  | https://edge.hedge.earth/emissionless/owner/repo/shapeshifter/path/id  |
-| POST  | https://edge.hedge.earth/emissionless/owner/repo/shapeshifter/path/id  |
-
 > The emissionless API is the first carbon aware API being bounced to low intensity data centers using HEDGE.earth. You can follow in our footsteps by submitting a pull requests for your service to our [HEDGE objects dev repo](https://github.com/rollthecloudinc/hedge-objects/tree/dev/services). Once you have tested, verified HEDGE.earth works with your API submit a pull request to [HEDGE objects prod repo](https://github.com/rollthecloudinc/hedge-objects-prod/tree/master/services). See our [emissionless.json](https://store.hedge.earth/services/emissionless.json) service schema for reference and [_schema.json](https://store.hedge.earth/services/_schema.json) for json schema defination of a HEDGE service. Valid regions can be found in the [regions json file](https://store.hedge.earth/regions/regions.json).
 
 The POST body can be any valid JSON with an id property. The id property is used to distinguish unique json documents within the same provided path. The id of the parameter should match the id inside the json document body.

--- a/README.md
+++ b/README.md
@@ -154,8 +154,8 @@ Store Media and other files under 100MB in Github easily.
 
 ## Follow Us
 
-* Twitter: @rollthecloud
-* Facebook : facebook.com/rollthecloud
+* [Twitter](https://twitter.com/rollthecloud)
+* [Facebook](https://www.facebook.com/rollthecloud)
 
 ## Contribute
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ HEDGE has HUGE potential reach and potential CO2 reduction impact, with over 90%
 
 <img width="224" alt="Screen Shot 2022-11-07 at 7 42 26 PM" src="https://user-images.githubusercontent.com/73197190/200446064-8fb570e3-e0f2-4659-a19e-dda084c8a33e.png">
 
-* **Problem:** Traditional databases are resources intensive and wastful.
+* **Problem:** Traditional databases are resource intensive and wastful.
 * **Solution:** Store data without adding more resources.
 
 **Resolution:**

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ HEDGE has HUGE potential reach and potential CO2 reduction impact, with over 90%
 
 Supercharge Github repos with RESTful APIs to store everything in Github easily.
 
-### Shapeshifter API
+### Octostore: Shapeshifter API
 
 Store JSON in Github easily.
 
@@ -135,6 +135,6 @@ Future Features:
 
 > Shapeshifter original intent was efficient cost effective means of storing [NxRx Data](https://v8.ngrx.io/guide/data) Entities. The API is being used exclusively with [Quell](https://github.com/rollthecloudinc/quell) our nonprofits carbon free low code editor on Reactive Angular. Quell relies heavily on NxRx Data to streamline managing data between the server and browser. Quell entities are currently hard coded into emissionless. Shapshifters goal is to enable a free flow of JSON of all entity types without needing to redeploy, modify emissionless.
 
-### Media API
+### Octostore: Media API
 
 Store Media and other files under 100MB in Github easily.

--- a/README.md
+++ b/README.md
@@ -143,17 +143,19 @@ Future Features:
 
 Store Media and other files under 100MB in Github easily.
 
-# Contact Us
+# Support
+
+## Contact Us
 
 * Email: hi@rollthecloud.com
 * Phone: (848) 274-2959
 
-# Follow Us
+## Follow Us
 
 * Twitter: @rollthecloud
 * Facebook : facebook.com/rollthecloud
 
-# Contribute
+## Contribute
 
 * Code: github.com/rollthecloudinc
 * Cash: [Paypal Giving Fund](https://www.paypal.com/fundraiser/charity/4587641)

--- a/README.md
+++ b/README.md
@@ -139,6 +139,10 @@ Future Features:
 
 Store Media and other files under 100MB in Github easily.
 
+### Octostore: Large Object API
+
+Store Media and other files over 100MB in Github easily.
+
 # Support
 
 Roll the Cloud INC. is a registered 501(c)3 nonprofit US charity with the mission to exhile carbon from the web.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-> Roll The Cloud Inc. is a registered US 501(c)3 charity. All proceeds go to building a more sustainable web. More information about our missions and obligations as a nonprofit can be found on our website: https://rollthecloud.com.
+> Roll The Cloud Inc. is a registered US 501(c)3 charity. All proceeds go to building a more sustainable web.
 
 ![](https://user-images.githubusercontent.com/73197190/196969015-5c967955-ea75-4a51-ae55-7dd47155d402.png)
 

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Store Media and other files under 100MB in Github easily.
 
 # Support
 
-Roll the Cloud INC. is a registered 501(c)3 nonprofit US charity whose mission is to exhile carbon from the web.
+Roll the Cloud INC. is a registered 501(c)3 nonprofit US charity with the mission to exhile carbon from the web.
 
 ## Contact Us
 

--- a/README.md
+++ b/README.md
@@ -142,3 +142,18 @@ Future Features:
 ### Octostore: Media API
 
 Store Media and other files under 100MB in Github easily.
+
+# Contact Us
+
+* Email: hi@rollthecloud.com
+* Phone: (848) 274-2959
+
+# Follow Us
+
+* Twitter: @rollthecloud
+* Facebook : facebook.com/rollthecloud
+
+# Contribute
+
+Code: github.com/rollthecloudinc
+Cash: Paypal Giving Fund

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Repair data storage providing repos with RESTful APIs to store everything in Git
 
 > Globally distributed data store with variable cpu operation within the cleanest data grids.
 
-### Octostore: Shapeshifter API
+### Octostore: JSON API (aka: Shapeshifter)
 
 Store JSON in Github easily.
 

--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ HEDGE has HUGE potential reach and potential CO2 reduction impact, with over 90%
 
 <img width="224" alt="Screen Shot 2022-11-07 at 7 42 26 PM" src="https://user-images.githubusercontent.com/73197190/200446064-8fb570e3-e0f2-4659-a19e-dda084c8a33e.png">
 
-* **Problem:** Traditional databases require large amounts of electricity creating large emissions.
-* **Solution:** Piggback on the leader of code collaboration restoring data storage to good planetary health.
+* **Problem:** Traditional databases are resources intensive and wastful.
+* **Solution:** Repair data storage by using Github for storage.
 
 **Resolution:**
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ HEDGE has HUGE potential reach and potential CO2 reduction impact, with over 90%
 
 **Resolution:**
 
-Repair data storage providing repos with RESTful APIs to store everything in Github easily.
+Repair data storage providing repos with RESTful APIs to store everything in Github easily. Github becomes a master storage solution with automatic hsitorical retention and sustainaible content distribution via CDN like Github Pages.
 
 ### Octostore: Shapeshifter API
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-> Roll The Cloud Inc. is a registered US 501(c)3 charity. All proceeds go to building a more sustainable web. More information about our missions and obligations as a nonprofit can be found on our website: https://rollthecloud.com. [Donations](https://www.paypal.com/fundraiser/charity/4587641) and [apparel shop](https://www.bonfire.com/store/climatewarrior/) available for those that would like to give a little to support the missions.
+> Roll The Cloud Inc. is a registered US 501(c)3 charity. All proceeds go to building a more sustainable web. More information about our missions and obligations as a nonprofit can be found on our website: https://rollthecloud.com.
 
 ![](https://user-images.githubusercontent.com/73197190/196969015-5c967955-ea75-4a51-ae55-7dd47155d402.png)
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ HEDGE has HUGE potential reach and potential CO2 reduction impact, with over 90%
 * Nginx and HaProxy extension
 * Other configuration as code platforms
 
+<img width="224" alt="Screen Shot 2022-11-07 at 7 42 26 PM" src="https://user-images.githubusercontent.com/73197190/200446064-8fb570e3-e0f2-4659-a19e-dda084c8a33e.png">
+
+
 ## Octostore
 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![](https://user-images.githubusercontent.com/73197190/196969015-5c967955-ea75-4a51-ae55-7dd47155d402.png)
 
-# APIs
+# Initiatives
 
 ![hedge_earth_identity_small](https://user-images.githubusercontent.com/73197190/199803427-1e5818d0-a925-462b-b8c1-27fb9588ba7b.png)
 

--- a/README.md
+++ b/README.md
@@ -69,14 +69,25 @@ HEDGE has HUGE potential reach and potential CO2 reduction impact, with over 90%
 * Nginx and HaProxy extension
 * Other configuration as code platforms
 
-## Shapeshifter
+## Octostore
+
 
 * **Problem:** Traditional databases are clunky, complex and consume a large amount of resources and energy.
 * **Solution:** Create a lightweight low resource storage without sacrificing availability, latency, performance.
 
-**Resolution:**
+### Shapeshifter
+
+**Resolution For JSON Storage:**
 
 Supercharge Github repos with RESTful APIs to easily commit JSON.
+
+| Method | HEDGE.earth |
+| ------------- | ------------- |
+| GET  | https://edge.hedge.earth/octostore/owner/repo/shapeshifter/path/id  |
+| PUT  | https://edge.hedge.earth/octostore/owner/repo/shapeshifter/path/id  |
+| POST  | https://edge.hedge.earth/octostore/owner/repo/shapeshifter/path/id  |
+
+deprecated:
 
 | Method | HEDGE.earth |
 | ------------- | ------------- |
@@ -122,6 +133,8 @@ Future Features:
 
 > Shapeshifter original intent was efficient cost effective means of storing [NxRx Data](https://v8.ngrx.io/guide/data) Entities. The API is being used exclusively with [Quell](https://github.com/rollthecloudinc/quell) our nonprofits carbon free low code editor on Reactive Angular. Quell relies heavily on NxRx Data to streamline managing data between the server and browser. Quell entities are currently hard coded into emissionless. Shapshifters goal is to enable a free flow of JSON of all entity types without needing to redeploy, modify emissionless.
 
-# Media
+### Media
+
+**Resolution For File Storage:**
 
 Supercharge Github repos with API to upload media files

--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ HEDGE has HUGE potential reach and potential CO2 reduction impact, with over 90%
 ## Octostore
 
 
-* **Problem:** Traditional databases are clunky, complex and consume a large amount of resources and energy.
-* **Solution:** Create a lightweight low resource storage without sacrificing availability, latency, performance.
+* **Problem:** Traditional databases require large amounts of electricity creating large emissions.
+* **Solution:** Piggback on the leader of code storage restoring data storage to good planetary health.
 
 **Resolution:**
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Initiatives
 
 * HEDGE: rewriting the web for good.
-* Octostore: sustainable low resource storage without sacrifice.
+* Octostore: repairing data storage for good.
 
 ## HEDGE
 

--- a/README.md
+++ b/README.md
@@ -74,11 +74,11 @@ HEDGE has HUGE potential reach and potential CO2 reduction impact, with over 90%
 <img width="224" alt="Screen Shot 2022-11-07 at 7 42 26 PM" src="https://user-images.githubusercontent.com/73197190/200446064-8fb570e3-e0f2-4659-a19e-dda084c8a33e.png">
 
 * **Problem:** Traditional databases are resources intensive and wastful.
-* **Solution:** Repair data storage by using Github.
+* **Solution:** Store data without adding more resources.
 
 **Resolution:**
 
-Supercharge Github repos with RESTful APIs to store everything in Github easily.
+Repair data storage by supercharge repos with RESTful APIs to store everything in Github easily.
 
 ### Octostore: Shapeshifter API
 

--- a/README.md
+++ b/README.md
@@ -149,8 +149,7 @@ Store Media and other files under 100MB in Github easily.
 
 ## Contact Us
 
-* Email: hi@rollthecloud.com
-* Phone: (848) 274-2959
+* [Email](hi@rollthecloud.com)
 
 ## Follow Us
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ HEDGE has HUGE potential reach and potential CO2 reduction impact, with over 90%
 
 Repair data storage providing repos with RESTful APIs to store everything in Github easily. Github becomes a master storage solution with automatic hsitorical retention and sustainaible content distribution via CDN like Github Pages. Also wraps transactions in electricity and carbon emissions tracking for a complete picture of emissions. Lastly distributed around the world at edge locations using HEDGE to bounce traffic to the data center with lowest carbon intensity grid. Ocotostore is one of the very first fully functional carbon aware APIs.
 
+> Globally distributed data store with variable cpu operation within the cleanest data grids.
+
 ### Octostore: Shapeshifter API
 
 Store JSON in Github easily.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+> Roll The Cloud Inc. is a registered US 501(c)3 charity. All proceeds go to building a more sustainable web. More information about our missions and obligations as a nonprofit can be found on our website: https://rollthecloud.com
+
 ![](https://user-images.githubusercontent.com/73197190/196969015-5c967955-ea75-4a51-ae55-7dd47155d402.png)
 
 # Initiatives

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ HEDGE has HUGE potential reach and potential CO2 reduction impact, with over 90%
 
 **Resolution:**
 
-Repair data storage providing repos with RESTful APIs to store everything in Github easily. Github becomes a master storage solution with automatic hsitorical retention and sustainaible content distribution via CDN like Github Pages.
+Repair data storage providing repos with RESTful APIs to store everything in Github easily. Github becomes a master storage solution with automatic hsitorical retention and sustainaible content distribution via CDN like Github Pages. Also wraps transactions in electricity and carbon emissions tracking for a complete picture of emissions. Lastly distributed around the world at edge locations using HEDGE to bounce traffic to the data center with lowest carbon intensity grid.
 
 ### Octostore: Shapeshifter API
 

--- a/README.md
+++ b/README.md
@@ -75,11 +75,13 @@ HEDGE has HUGE potential reach and potential CO2 reduction impact, with over 90%
 * **Problem:** Traditional databases are clunky, complex and consume a large amount of resources and energy.
 * **Solution:** Create a lightweight low resource storage without sacrificing availability, latency, performance.
 
-### Shapeshifter
+**Resolution:**
 
-**Resolution For JSON Storage:**
+Supercharge Github repos with RESTful APIs to store everything in Github easily.
 
-Supercharge Github repos with RESTful APIs to easily commit JSON.
+### Shapeshifter API
+
+Store JSON in Github easily.
 
 | Method | HEDGE.earth |
 | ------------- | ------------- |
@@ -133,8 +135,6 @@ Future Features:
 
 > Shapeshifter original intent was efficient cost effective means of storing [NxRx Data](https://v8.ngrx.io/guide/data) Entities. The API is being used exclusively with [Quell](https://github.com/rollthecloudinc/quell) our nonprofits carbon free low code editor on Reactive Angular. Quell relies heavily on NxRx Data to streamline managing data between the server and browser. Quell entities are currently hard coded into emissionless. Shapshifters goal is to enable a free flow of JSON of all entity types without needing to redeploy, modify emissionless.
 
-### Media
+### Media API
 
-**Resolution For File Storage:**
-
-Supercharge Github repos with API to upload media files
+Store Media and other files under 100MB in Github easily.

--- a/README.md
+++ b/README.md
@@ -159,5 +159,5 @@ Store Media and other files under 100MB in Github easily.
 
 ## Contribute
 
-* Code: github.com/rollthecloudinc
-* Cash: [Paypal Giving Fund](https://www.paypal.com/fundraiser/charity/4587641)
+* [Github](github.com/rollthecloudinc)
+* [Paypal Giving Fund](https://www.paypal.com/fundraiser/charity/4587641)

--- a/README.md
+++ b/README.md
@@ -2,9 +2,12 @@
 
 # Initiatives
 
-![hedge_earth_identity_small](https://user-images.githubusercontent.com/73197190/199803427-1e5818d0-a925-462b-b8c1-27fb9588ba7b.png)
+* HEDGE: rewriting the web for good.
+* Octostore: sustainable low resource storage without sacrifice.
 
 ## HEDGE
+
+![hedge_earth_identity_small](https://user-images.githubusercontent.com/73197190/199803427-1e5818d0-a925-462b-b8c1-27fb9588ba7b.png)
 
 * **Problem:** API requests contribute to 83% of web carbon emissions
 * **Solution:** Maximize amount of clean energy used to fulfill API requests

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ HEDGE has HUGE potential reach and potential CO2 reduction impact, with over 90%
 
 
 * **Problem:** Traditional databases require large amounts of electricity creating large emissions.
-* **Solution:** Piggback on the leader of code storage restoring data storage to good planetary health.
+* **Solution:** Piggback on the leader of code collaboration restoring data storage to good planetary health.
 
 **Resolution:**
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@
 
 To this end our contribution to reducing web carbon begins with generating a [periodical](https://github.com/rollthecloudinc/hedge-objects-prod/commits/master/renewable-report) [renewables report](https://store.hedge.earth/renewable-report/report.json) of regional grid intensity levels across the globe from the [Green Software Foundation](https://greensoftware.foundation/) [carbon aware api](https://carbon-aware-api.azurewebsites.net/swagger/index.html) for the next 5 minutes. The generated renewable report is used to redirect API requests to data centers within regions that are using the lowest carbon intense [power sources](https://www.watttime.org/explorer/). The API requests are redirected based on reported intensity levels inside the renewable report. Rewriting the definition of a reverse proxy to include the advantage of maximizing clean energy use.
 
+> HEDGING (Software Development): Limiting software exposure to carbon by chosing sources to run software on cleanest energy.
+
 Reverse proxy: 
 
 An application that sits in front of back-end applications and forwards client requests to those applications. Reverse proxies help increase scalability, performance, resilience, security and clean energy use. The HEDGE reverse proxy url is below for both the prod and dev environments. Request to register services will be promoted to prod once tested on dev via pull requests.

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 # Initiatives
 
-* HEDGE: rewriting the web for good.
-* Octostore: repairing data storage for good.
+* HEDGE: Rewriting the web for good.
+* Octostore: Repairing data storage for good.
 
 ## HEDGE
 

--- a/README.md
+++ b/README.md
@@ -155,5 +155,5 @@ Store Media and other files under 100MB in Github easily.
 
 # Contribute
 
-Code: github.com/rollthecloudinc
-Cash: Paypal Giving Fund
+* Code: github.com/rollthecloudinc
+* Cash: [Paypal Giving Fund](https://www.paypal.com/fundraiser/charity/4587641)

--- a/README.md
+++ b/README.md
@@ -69,11 +69,9 @@ HEDGE has HUGE potential reach and potential CO2 reduction impact, with over 90%
 * Nginx and HaProxy extension
 * Other configuration as code platforms
 
-<img width="224" alt="Screen Shot 2022-11-07 at 7 42 26 PM" src="https://user-images.githubusercontent.com/73197190/200446064-8fb570e3-e0f2-4659-a19e-dda084c8a33e.png">
-
-
 ## Octostore
 
+<img width="224" alt="Screen Shot 2022-11-07 at 7 42 26 PM" src="https://user-images.githubusercontent.com/73197190/200446064-8fb570e3-e0f2-4659-a19e-dda084c8a33e.png">
 
 * **Problem:** Traditional databases require large amounts of electricity creating large emissions.
 * **Solution:** Piggback on the leader of code collaboration restoring data storage to good planetary health.

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ HEDGE has HUGE potential reach and potential CO2 reduction impact, with over 90%
 
 **Resolution:**
 
-Repair data storage by supercharge repos with RESTful APIs to store everything in Github easily.
+Repair data storage providing repos with RESTful APIs to store everything in Github easily.
 
 ### Octostore: Shapeshifter API
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-> Roll The Cloud Inc. is a registered US 501(c)3 charity. All proceeds go to building a more sustainable web. More information about our missions and obligations as a nonprofit can be found on our website: https://rollthecloud.com
+> Roll The Cloud Inc. is a registered US 501(c)3 charity. All proceeds go to building a more sustainable web. More information about our missions and obligations as a nonprofit can be found on our website: https://rollthecloud.com. [Donations](https://www.paypal.com/fundraiser/charity/4587641) and [apparel shop](https://www.bonfire.com/store/climatewarrior/) available for those that would like to give a little to support the missions.
 
 ![](https://user-images.githubusercontent.com/73197190/196969015-5c967955-ea75-4a51-ae55-7dd47155d402.png)
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ HEDGE has HUGE potential reach and potential CO2 reduction impact, with over 90%
 
 **Resolution:**
 
-Repair data storage providing repos with RESTful APIs to store everything in Github easily. Github becomes a master storage solution with automatic hsitorical retention and sustainaible content distribution via CDN like Github Pages. Also wraps transactions in electricity and carbon emissions tracking for a complete picture of emissions. Lastly distributed around the world at edge locations using HEDGE to bounce traffic to the data center with lowest carbon intensity grid.
+Repair data storage providing repos with RESTful APIs to store everything in Github easily. Github becomes a master storage solution with automatic hsitorical retention and sustainaible content distribution via CDN like Github Pages. Also wraps transactions in electricity and carbon emissions tracking for a complete picture of emissions. Lastly distributed around the world at edge locations using HEDGE to bounce traffic to the data center with lowest carbon intensity grid. Ocotostore is one of the very first fully functional carbon aware APIs.
 
 ### Octostore: Shapeshifter API
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-> Roll The Cloud Inc. is a registered US 501(c)3 charity. All proceeds go to building a more sustainable web.
-
 ![](https://user-images.githubusercontent.com/73197190/196969015-5c967955-ea75-4a51-ae55-7dd47155d402.png)
 
 # Initiatives

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Store Media and other files under 100MB in Github easily.
 
 ## Contact Us
 
-* [Email](hi@rollthecloud.com)
+* [Email](mailto:hi@rollthecloud.com)
 
 ## Follow Us
 

--- a/api/entity/BUILD.bazel
+++ b/api/entity/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//lib/entity",
         "//lib/sign",
         "//lib/gov",
+        "//lib/repo",
         "@com_github_aws_aws_lambda_go//events",
         "@com_github_aws_aws_lambda_go//lambda",
         "@com_github_aws_aws_sdk_go//aws/session",

--- a/func/grant_access/main.go
+++ b/func/grant_access/main.go
@@ -65,6 +65,15 @@ func handler(ctx context.Context, payload *gov.GrantAccessRequest) (gov.GrantAcc
 
 	grant := len(results) != 0
 
+	if len(payload.AdditionalResources) != 0 {
+		for _, r := range payload.AdditionalResources {
+			if r.User == payload.User && r.Type == payload.Type && r.Resource == payload.Resource && r.Asset == payload.Asset && r.Operation == payload.Operation {
+				grant = true
+				break
+			}
+		}
+	}
+
 	return gov.GrantAccessResponse{
 		Grant: grant,
 	}, nil

--- a/lib/entity/entity.go
+++ b/lib/entity/entity.go
@@ -262,11 +262,12 @@ type OwnerAuthorizationConfig struct {
 }
 
 type ResourceOrOwnerAuthorizationConfig struct {
-	UserId   string `json:"userId"`
-	Site     string `json:"site"`
-	Resource gov.ResourceTypes
-	Asset    string
-	Lambda   *lambda.Lambda `json:"-"`
+	UserId              string `json:"userId"`
+	Site                string `json:"site"`
+	Resource            gov.ResourceTypes
+	Asset               string
+	Lambda              *lambda.Lambda  `json:"-"`
+	AdditionalResources *[]gov.Resource `json:"additional_resources"`
 }
 
 type DefaultCreatorConfig struct {
@@ -905,11 +906,12 @@ func (a OwnerAuthorizationAdaptor) CanWrite(id string, m *EntityManager) (bool, 
 func (a ResourceOrOwnerAuthorizationAdaptor) CanWrite(id string, m *EntityManager) (bool, map[string]interface{}) {
 
 	grantAccessRequest := gov.GrantAccessRequest{
-		User:      a.Config.UserId,
-		Type:      gov.User,
-		Resource:  a.Config.Resource,
-		Operation: gov.Write,
-		Asset:     a.Config.Asset,
+		User:                a.Config.UserId,
+		Type:                gov.User,
+		Resource:            a.Config.Resource,
+		Operation:           gov.Write,
+		Asset:               a.Config.Asset,
+		AdditionalResources: *a.Config.AdditionalResources,
 	}
 
 	payload, err := json.Marshal(grantAccessRequest)

--- a/lib/gov/gov.go
+++ b/lib/gov/gov.go
@@ -43,6 +43,15 @@ var OperationMap = map[string]ResourceOperations{
 type ResourceOperations int32
 
 type GrantAccessRequest struct {
+	User                string
+	Type                ResourceUserTypes
+	Resource            ResourceTypes
+	Asset               string
+	Operation           ResourceOperations
+	AdditionalResources []Resource
+}
+
+type Resource struct {
 	User      string
 	Type      ResourceUserTypes
 	Resource  ResourceTypes

--- a/serverless.yml
+++ b/serverless.yml
@@ -153,6 +153,8 @@ functions:
       USER_POOL_ID: ${self:custom.userPoolId}
       IDENTITY_POOL_ID: ${self:custom.identityPoolId}
       ISSUER: ${self:custom.issuer}
+      DEFAULT_SIGNING_USERNAME: ${self:custom.defaultSigningUsername}
+      DEFAULT_SIGNING_PASSWORD: ${self:custom.defaultSigningPassword}
       STAGE: ${opt:stage, 'dev'}
     events:
       - httpApi:


### PR DESCRIPTION
Normally write access to repositories is guarded by an access control that requires explicit grant by adding a row to the resources2 key spaces table. However, owners are granted implicit write access to repositories they explicitly own. This simplifies the process of installing the climate warrior app ready for immediate use. Repositories which the user does not own but has access to requires explicit grants currently. However, there will be a ui and some automation in the future.