### PR TITLE
[tz-92] Allow owners to write their own repositories without requiring explicit permissions.

### DIFF
--- a/api/entity/BUILD.bazel
+++ b/api/entity/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//lib/entity",
         "//lib/sign",
         "//lib/gov",
+        "//lib/repo",
         "@com_github_aws_aws_lambda_go//events",
         "@com_github_aws_aws_lambda_go//lambda",
         "@com_github_aws_aws_sdk_go//aws/session",

--- a/func/grant_access/main.go
+++ b/func/grant_access/main.go
@@ -65,6 +65,15 @@ func handler(ctx context.Context, payload *gov.GrantAccessRequest) (gov.GrantAcc
 
 	grant := len(results) != 0
 
+	if len(payload.AdditionalResources) != 0 {
+		for _, r := range payload.AdditionalResources {
+			if r.User == payload.User && r.Type == payload.Type && r.Resource == payload.Resource && r.Asset == payload.Asset && r.Operation == payload.Operation {
+				grant = true
+				break
+			}
+		}
+	}
+
 	return gov.GrantAccessResponse{
 		Grant: grant,
 	}, nil

--- a/lib/entity/entity.go
+++ b/lib/entity/entity.go
@@ -262,11 +262,12 @@ type OwnerAuthorizationConfig struct {
 }
 
 type ResourceOrOwnerAuthorizationConfig struct {
-	UserId   string `json:"userId"`
-	Site     string `json:"site"`
-	Resource gov.ResourceTypes
-	Asset    string
-	Lambda   *lambda.Lambda `json:"-"`
+	UserId              string `json:"userId"`
+	Site                string `json:"site"`
+	Resource            gov.ResourceTypes
+	Asset               string
+	Lambda              *lambda.Lambda  `json:"-"`
+	AdditionalResources *[]gov.Resource `json:"additional_resources"`
 }
 
 type DefaultCreatorConfig struct {
@@ -905,11 +906,12 @@ func (a OwnerAuthorizationAdaptor) CanWrite(id string, m *EntityManager) (bool, 
 func (a ResourceOrOwnerAuthorizationAdaptor) CanWrite(id string, m *EntityManager) (bool, map[string]interface{}) {
 
 	grantAccessRequest := gov.GrantAccessRequest{
-		User:      a.Config.UserId,
-		Type:      gov.User,
-		Resource:  a.Config.Resource,
-		Operation: gov.Write,
-		Asset:     a.Config.Asset,
+		User:                a.Config.UserId,
+		Type:                gov.User,
+		Resource:            a.Config.Resource,
+		Operation:           gov.Write,
+		Asset:               a.Config.Asset,
+		AdditionalResources: *a.Config.AdditionalResources,
 	}
 
 	payload, err := json.Marshal(grantAccessRequest)

--- a/lib/gov/gov.go
+++ b/lib/gov/gov.go
@@ -43,6 +43,15 @@ var OperationMap = map[string]ResourceOperations{
 type ResourceOperations int32
 
 type GrantAccessRequest struct {
+	User                string
+	Type                ResourceUserTypes
+	Resource            ResourceTypes
+	Asset               string
+	Operation           ResourceOperations
+	AdditionalResources []Resource
+}
+
+type Resource struct {
 	User      string
 	Type      ResourceUserTypes
 	Resource  ResourceTypes

--- a/serverless.yml
+++ b/serverless.yml
@@ -153,6 +153,8 @@ functions:
       USER_POOL_ID: ${self:custom.userPoolId}
       IDENTITY_POOL_ID: ${self:custom.identityPoolId}
       ISSUER: ${self:custom.issuer}
+      DEFAULT_SIGNING_USERNAME: ${self:custom.defaultSigningUsername}
+      DEFAULT_SIGNING_PASSWORD: ${self:custom.defaultSigningPassword}
       STAGE: ${opt:stage, 'dev'}
     events:
       - httpApi:


### PR DESCRIPTION
Normally write access to repositories is guarded by an access control that requires explicit grant by adding a row to the resources2 key spaces table. However, owners are granted implicit write access to repositories they explicitly own. This simplifies the process of installing the climate warrior app ready for immediate use. Repositories which the user does not own but has access to requires explicit grants currently. However, there will be a ui and some automation in the future.